### PR TITLE
feat: save training and test metrics to JSON after training

### DIFF
--- a/configs/train_config.yml
+++ b/configs/train_config.yml
@@ -30,6 +30,14 @@ model:
     iou:
       type: "iou"
       threshold: 0.5
+    # hausdorff:
+    #   type: "hausdorff"
+    #   threshold: 0.5
+    #   percentile: 95
+    accuracy:
+      type: "accuracy"
+      threshold: 0.5
+      per_class: false
 
 # Data configuration
 data:

--- a/configs/train_config_3d.yml
+++ b/configs/train_config_3d.yml
@@ -40,7 +40,7 @@ data:
   train_val_split: [0.8, 0.2]
   dataset_args:  
     image_subdir: "images" 
-    mask_subdir: "masks"   
+    mask_subdir: "masks"
     image_suffix: "*.nii.gz"  
     mask_suffix: "*.nii.gz" 
 
@@ -52,78 +52,78 @@ data:
       mode: ["bilinear", "nearest"]
       align_corners: [false, null]
     
-#     # 2. 空间变换 - 提升泛化能力
-#     RandRotated:
-#       keys: ["image", "label"]
-#       range_x: 0.2  # ±0.2弧度 ≈ ±11.5度
-#       range_y: 0.2
-#       prob: 0.5
-#       mode: ["bilinear", "nearest"]
-#       padding_mode: "border"
-#       align_corners: [false, null]
+    # 2. 空间变换 - 提升泛化能力
+    RandRotated:
+      keys: ["image", "label"]
+      range_x: 0.2  # ±0.2弧度 ≈ ±11.5度
+      range_y: 0.2
+      prob: 0.5
+      mode: ["bilinear", "nearest"]
+      padding_mode: "border"
+      align_corners: [false, null]
     
-#     RandFlipd:
-#       keys: ["image", "label"]
-#       spatial_axis: [0, 1]  # 水平和垂直翻转
-#       prob: 0.5
+    RandFlipd:
+      keys: ["image", "label"]
+      spatial_axis: [0, 1]  # 水平和垂直翻转
+      prob: 0.5
     
-#     RandAffined:
-#       keys: ["image", "label"]
-#       prob: 0.3
-#       rotate_range: [0.1, 0.1]  # 小角度旋转
-#       scale_range: [0.1, 0.1]   # 缩放范围 0.9-1.1
-#       translate_range: [10, 10] # 平移像素数
-#       mode: ["bilinear", "nearest"]
-#       padding_mode: "border"
-#       align_corners: [false, null]
+    RandAffined:
+      keys: ["image", "label"]
+      prob: 0.3
+      rotate_range: [0.1, 0.1]  # 小角度旋转
+      scale_range: [0.1, 0.1]   # 缩放范围 0.9-1.1
+      translate_range: [10, 10] # 平移像素数
+      mode: ["bilinear", "nearest"]
+      padding_mode: "border"
+      align_corners: [false, null]
     
-#     RandZoomd:
-#       keys: ["image", "label"]
-#       min_zoom: 0.85
-#       max_zoom: 1.15
-#       prob: 0.3
-#       mode: ["bilinear", "nearest"]
-#       align_corners: [false, null]
+    RandZoomd:
+      keys: ["image", "label"]
+      min_zoom: 0.85
+      max_zoom: 1.15
+      prob: 0.3
+      mode: ["bilinear", "nearest"]
+      align_corners: [false, null]
     
-#     # 3. 强度变换（仅对图像）
-#     RandAdjustContrastd:
-#       keys: ["image"]
-#       prob: 0.3
-#       gamma: [0.8, 1.2]  # 对比度调整范围
+    # 3. 强度变换（仅对图像）
+    RandAdjustContrastd:
+      keys: ["image"]
+      prob: 0.3
+      gamma: [0.8, 1.2]  # 对比度调整范围
     
-#     RandScaleIntensityd:
-#       keys: ["image"]
-#       factors: 0.2  # 强度缩放因子
-#       prob: 0.3
+    RandScaleIntensityd:
+      keys: ["image"]
+      factors: 0.2  # 强度缩放因子
+      prob: 0.3
     
-#     RandShiftIntensityd:
-#       keys: ["image"]
-#       offsets: 0.1  # 强度偏移
-#       prob: 0.3
+    RandShiftIntensityd:
+      keys: ["image"]
+      offsets: 0.1  # 强度偏移
+      prob: 0.3
     
-#     RandGaussianNoised:
-#       keys: ["image"]
-#       prob: 0.2
-#       mean: 0.0
-#       std: 0.1
+    RandGaussianNoised:
+      keys: ["image"]
+      prob: 0.2
+      mean: 0.0
+      std: 0.1
     
-#     RandGaussianSmoothd:
-#       keys: ["image"]
-#       prob: 0.1
-#       sigma_x: [0.5, 1.0]
-#       sigma_y: [0.5, 1.0]
+    RandGaussianSmoothd:
+      keys: ["image"]
+      prob: 0.1
+      sigma_x: [0.5, 1.0]
+      sigma_y: [0.5, 1.0]
     
-#     RandBiasFieldd:
-#       keys: ["image"]
-#       prob: 0.15
-#       degree: 3
-#       coeff_range: [0.0, 0.1]
+    RandBiasFieldd:
+      keys: ["image"]
+      prob: 0.15
+      degree: 3
+      coeff_range: [0.0, 0.1]
     
-#     # 4. 归一化
-#     NormalizeIntensityd:
-#       keys: ["image"]
-#       nonzero: true
-#       channel_wise: false
+    # 4. 归一化
+    NormalizeIntensityd:
+      keys: ["image"]
+      nonzero: true
+      channel_wise: false
   val_transforms:
     # 验证时只做基础预处理
     Resized:

--- a/medvision/metrics/__init__.py
+++ b/medvision/metrics/__init__.py
@@ -3,11 +3,13 @@
 from .dice import DiceCoefficient
 from .iou import IoU
 from .accuracy import Accuracy
+from .hausdorff import HausdorffDistance
 from .factory import get_metrics
 
 __all__ = [
     'DiceCoefficient',
     'IoU',
     'Accuracy',
+    'HausdorffDistance',
     'get_metrics'
 ]

--- a/medvision/metrics/factory.py
+++ b/medvision/metrics/factory.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Callable
 from .dice import DiceCoefficient
 from .iou import IoU
 from .accuracy import Accuracy
+from .hausdorff import HausdorffDistance
 
 
 def get_metrics(config: Dict[str, Any]) -> Dict[str, Callable]:
@@ -21,7 +22,6 @@ def get_metrics(config: Dict[str, Any]) -> Dict[str, Callable]:
     
     for metric_name, metric_config in config.items():
         metric_type = metric_config["type"].lower()
-        
         if metric_type == "dice":
             metrics[metric_name] = DiceCoefficient(
                 smooth=metric_config.get("smooth", 1e-6),
@@ -38,6 +38,11 @@ def get_metrics(config: Dict[str, Any]) -> Dict[str, Callable]:
             metrics[metric_name] = Accuracy(
                 threshold=metric_config.get("threshold", 0.5),
                 per_class=metric_config.get("per_class", False)
+            )
+        elif metric_type == "hausdorff":
+            metrics[metric_name] = HausdorffDistance(
+                threshold=metric_config.get("threshold", 0.5),
+                percentile=metric_config.get("percentile", 95)
             )
         else:
             raise ValueError(f"Unknown metric type: {metric_type}")


### PR DESCRIPTION
- Added functionality to automatically save training and test metrics at the end of training.
- Metrics include training/validation losses from trainer.callback_metrics and test results from trainer.test().
- Also included the best model checkpoint path and score.
- The metrics are saved as a JSON file (results.json) in the output directory specified by the config.
- Controlled via a config["training"]["save_metrics"] flag (default: True).